### PR TITLE
Update VaultSecretSource.java

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -50,6 +50,7 @@ public class VaultSecretSource extends SecretSource {
         String vaultAppRole = getVariable("CASC_VAULT_APPROLE", prop);
         String vaultAppRoleSecret = getVariable("CASC_VAULT_APPROLE_SECRET", prop);
         String vaultNamespace = getVariable("CASC_VAULT_NAMESPACE", prop);
+        String vaultEngineVersion = getVariable("CASC_VAULT_ENGINE_VERSION", prop);
 
         if(((vaultPw != null && vaultUsr != null) || 
             vaultToken != null || 
@@ -61,6 +62,10 @@ public class VaultSecretSource extends SecretSource {
                     // optionally set namespace
                     config = config.nameSpace(vaultNamespace);
                     LOGGER.log(Level.FINE, "Using namespace with Vault: {0}", vaultNamespace);
+                }
+                if (vaultEngineVersion == 1 || vaultEngineVersion == 2 ) {
+                    // optionally set vault engine version
+                    config.setEngineVersion(vaultEngineVersion)
                 }
                 config = config.build();
                 Vault vault = new Vault(config);


### PR DESCRIPTION
Here is our checklist for contributors. No hard requirement here, just a reminder

- [ ] Please describe what you did
Allow user to specify which vault engine version to use. The update "vault-java-driver to 4.0.0" broke all vault reads for users on engine version 1. The new vault-java-driver defaults to version 2, but supports specifying the engine version. https://github.com/jenkinsci/configuration-as-code-plugin/pull/741

- [ ] Link to issue you're working on if there's a relevant one
https://github.com/jenkinsci/configuration-as-code-plugin/issues/746
